### PR TITLE
Add API for setting the amperage limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ for charger_id in chargers:
 #   reminder_enabled=False, 
 #   reminder_time='21:00', 
 #   model='CPH50-NEMA6-50-L23', 
-#   mac_address='0024B10000012345')
+#   mac_address='0024B10000012345',
+#   amperage_limit=25,
+#   possible_amperage_limits=[20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32])
 ```
 
 ### Account Charging Status and Session
@@ -164,4 +166,21 @@ home_flex = client.get_home_charger_status(home_flex_id)
 
 if home_flex.charging_status == "AVAILABLE":
     session = client.start_charging_session(home_flex_id)
+```
+
+#### Setting the amperage limit
+
+```python
+from python_chargepoint import ChargePoint
+
+client = ChargePoint(username="user", password="password")
+home_flex_id = client.get_home_chargers()[0]
+
+# Print out valid amperage values.
+print(client.get_home_charger_status(home_flex_id).possible_amperage_limits)
+# [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]
+
+client.set_amperage_limit(home_flex_id, 23)
+print(client.get_home_charger_status(home_flex_id).amperage_limit)
+# 23
 ```

--- a/python_chargepoint/global_config.py
+++ b/python_chargepoint/global_config.py
@@ -53,6 +53,7 @@ def _safe_get_endpoint(json: dict, endpoint_key: str) -> str:
 @dataclass
 class ChargePointEndpoints:
     accounts: str
+    internal_api: str
     mapcache: str
     panda_websocket: str
     payment_java: str
@@ -67,6 +68,7 @@ class ChargePointEndpoints:
     def from_json(cls, json: dict):
         return cls(
             accounts=_safe_get_endpoint(json, "accounts_endpoint"),
+            internal_api=_safe_get_endpoint(json, "internal_api_gateway_endpoint"),
             mapcache=_safe_get_endpoint(json, "mapcache_endpoint"),
             panda_websocket=_safe_get_endpoint(json, "panda_websocket_endpoint"),
             payment_java=_safe_get_endpoint(json, "payment_java_endpoint"),

--- a/python_chargepoint/types.py
+++ b/python_chargepoint/types.py
@@ -102,6 +102,8 @@ class HomeChargerStatus:
     reminder_time: str
     model: str
     mac_address: str
+    amperage_limit: int
+    possible_amperage_limits: List[int]
 
     @classmethod
     def from_json(cls, charger_id: int, json: dict):
@@ -118,6 +120,8 @@ class HomeChargerStatus:
             reminder_time=json.get("plug_in_reminder_time", ""),
             model=json.get("model", ""),
             mac_address=json.get("mac_address", "00:00:00:00:00:00"),
+            amperage_limit=json.get("charge_amperage_setting", {}).get("charge_limit", 0),
+            possible_amperage_limits=json.get("charge_amperage_setting", {}).get("possible_charge_limit", 0),
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,6 +115,10 @@ def home_charger_json(timestamp: datetime):
         "plug_in_reminder_time": "0:00",
         "model": "HOME FLEX",
         "mac_address": "00:00:00:00:00:00",
+        "charge_amperage_setting": {
+            "charge_limit": 28,
+            "possible_charge_limit": [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]
+        }
     }
 
 

--- a/tests/example/global_config.json
+++ b/tests/example/global_config.json
@@ -20,6 +20,10 @@
             "value": "https://account.chargepoint.com/account/",
             "dataDome": true
         },
+        "internal_api_gateway_endpoint": {
+            "value": "https://internal-api-us.chargepoint.com",
+            "dataDome": true
+        },
         "sso_endpoint": {
             "value": "https://sso.chargepoint.com/api/",
             "dataDome": true

--- a/tests/test_global_config.py
+++ b/tests/test_global_config.py
@@ -16,3 +16,4 @@ def test_global_configuration(global_config_json: dict):
     assert len(cfg.supported_currencies) == 11
 
     assert cfg.endpoints.accounts == "https://account.chargepoint.com/account/"
+    assert cfg.endpoints.internal_api == "https://internal-api-us.chargepoint.com"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -62,6 +62,8 @@ def test_home_charger_status_from_json(timestamp: datetime, home_charger_json: d
     assert home.reminder_time == "0:00"
     assert home.model == "HOME FLEX"
     assert home.mac_address == "00:00:00:00:00:00"
+    assert home.amperage_limit == 28
+    assert home.possible_amperage_limits == [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]
 
 
 def test_home_charger_technical_info_from_json(


### PR DESCRIPTION
This adds an api to the Client to allow for setting the new amperage limit. It also exposes the available values for the limit.

The goal is to use this information to add a new Number entity to the HA chargepoint integration (see:
https://github.com/mbillow/ha-chargepoint/issues/35)

API was discovered by sniffing packets from the ChargePoint app. Besides the included unit tests this was also tested with my local device and appears to work.