### PR TITLE
feat: add restart function

### DIFF
--- a/python_chargepoint/client.py
+++ b/python_chargepoint/client.py
@@ -399,6 +399,31 @@ class ChargePoint:
         raise ChargePointCommunicationException(
             response=response, message="New amperage limit did not persist to charger after retries"
         )
+    
+    @_require_login
+    def restart_home_charger(self, charger_id: int) -> None:
+        _LOGGER.debug("Sending restart command for panda: %s", charger_id)
+        restart = {
+            "user_id": self.user_id,
+            "restart_panda": {"device_id": charger_id, "mfhs": {}},
+        }
+        response = self._session.post(
+            f"{self._global_config.endpoints.webservices}mobileapi/v5", json=restart
+        )
+
+        if response.status_code != codes.ok:
+            _LOGGER.error(
+                "Failed to restart charger! status_code=%s err=%s",
+                response.status_code,
+                response.text,
+            )
+            raise ChargePointCommunicationException(
+                response=response, message="Failed to restart charger."
+            )
+
+        status = response.json()
+        _LOGGER.debug(status)
+        return
 
     @_require_login
     def get_charging_session(self, session_id: int) -> ChargingSession:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -394,17 +394,30 @@ def test_client_get_get_user_charging_status_failure(authenticated_client: Charg
     assert exc.value.response.status_code == 500
 
 @responses.activate
-def test_client_restart_home_charger(authenticated_client: ChargePoint):
+def test_client_restart_home_charger(authenticated_client: ChargePoint, home_charger_json: dict):
     responses.add(
         responses.POST,
-         f"{authenticated_client.global_config.endpoints.mapcache}mobileapi/v5",
+         f"{authenticated_client.global_config.endpoints.webservices}mobileapi/v5",
         status=200,
         json={"restart_panda": {}},
     )
 
-    status = authenticated_client.restart_home_charger()
+    status = authenticated_client.restart_home_charger(1234567890)
 
     assert status is None
+
+@responses.activate
+def test_client_restart_home_charger_failure(authenticated_client: ChargePoint, home_charger_json: dict):
+    responses.add(
+        responses.POST,
+         f"{authenticated_client.global_config.endpoints.webservices}mobileapi/v5",
+        status=500,
+    )
+
+    with pytest.raises(ChargePointCommunicationException) as exc:
+        authenticated_client.restart_home_charger(1234567890)
+
+    assert exc.value.response.status_code == 500
 
 @responses.activate
 def test_start_session(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -393,6 +393,18 @@ def test_client_get_get_user_charging_status_failure(authenticated_client: Charg
 
     assert exc.value.response.status_code == 500
 
+@responses.activate
+def test_client_restart_home_charger(authenticated_client: ChargePoint):
+    responses.add(
+        responses.POST,
+         f"{authenticated_client.global_config.endpoints.mapcache}mobileapi/v5",
+        status=200,
+        json={"restart_panda": {}},
+    )
+
+    status = authenticated_client.restart_home_charger()
+
+    assert status is None
 
 @responses.activate
 def test_start_session(


### PR DESCRIPTION
## Background
There have been times with my home charger that I've gotten back a 'fault' status when charging initiates as per the schedule. Usually a restart of the charger fixes this, but I have to go in the app, find the charger, and hit reboot. 

This little addition should eventually allow me to automate around any future 'fault' states.

side note... Thanks so much for this! It's helped lots @mbillow!

## Future
I plan on (if this is merged), adding this func as a Button entity to the HA repo as a quick followup!