### PR TITLE
SSO Login Endpoint and Session Token Refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
+*.ipynb
 
 # IPython
 profile_default/

--- a/python_chargepoint/client.py
+++ b/python_chargepoint/client.py
@@ -1,10 +1,9 @@
-from uuid import uuid4
 from typing import List, Optional
 from functools import wraps
 from time import sleep
 from importlib.metadata import version, PackageNotFoundError
 
-from requests import Session, codes, post
+from requests import Session, codes
 
 from .types import (
     ChargePointAccount,
@@ -55,12 +54,16 @@ class ChargePoint:
         self,
         username: str,
         password: str,
-        session_token: str = "",
+        session_token: Optional[str] = "",
     ):
         self._session = Session()
         self._user_id = None
         self._logged_in = False
-        self._session_token = None
+
+        self._session.headers = {
+                "user-agent": USER_AGENT,
+            }
+        
         self._global_config = self._get_configuration(username)
 
         if session_token:
@@ -69,6 +72,7 @@ class ChargePoint:
             try:
                 account: ChargePointAccount = self.get_account()
                 self._user_id = str(account.user.user_id)
+                self.refresh_session_token()
                 return
             except ChargePointCommunicationException:
                 _LOGGER.warning(
@@ -88,7 +92,7 @@ class ChargePoint:
 
     @property
     def session_token(self) -> Optional[str]:
-        return self._session_token
+        return self._get_session_token()
 
 
     @property
@@ -102,30 +106,27 @@ class ChargePoint:
         :param password: Account password
         """
         login_url = (
-            f"{self._global_config.endpoints.accounts}v2/driver/profile/account/login"
+            f"{self._global_config.endpoints.sso}v1/user/login"
         )
-        headers = {
-            "User-Agent": USER_AGENT
-        }
+        
         request = {
             "username": username,
             "password": password,
         }
         _LOGGER.debug("Attempting client login with user: %s", username)
-        login = post(login_url, json=request, headers=headers)
+        login = self._session.post(login_url, json=request)
         _LOGGER.debug(login.cookies.get_dict())
         _LOGGER.debug(login.headers)
 
         if login.status_code == codes.ok:
-            req = login.json()
-            self._user_id = req["user"]["userId"]
-            _LOGGER.debug("Authentication success! User ID: %s", self._user_id)
-            self._set_session_token(req["sessionId"])
             self._logged_in = True
+            account: ChargePointAccount = self.get_account()
+            self._user_id = str(account.user.user_id)
+            self.refresh_session_token()
             return
 
         _LOGGER.error(
-            "Failed to get account information! status_code=%s err=%s",
+            "Failed to get auth token! status_code=%s err=%s",
             login.status_code,
             login.text,
         )
@@ -133,7 +134,7 @@ class ChargePoint:
 
     def logout(self):
         response = self._session.post(
-            f"{self._global_config.endpoints.accounts}v1/driver/profile/account/logout",
+            f"{self._global_config.endpoints.sso}v1/user/logout",
         )
 
         if response.status_code != codes.ok:
@@ -141,9 +142,7 @@ class ChargePoint:
                 response=response, message="Failed to log out!"
             )
 
-        self._session.headers = {}
         self._session.cookies.clear_session_cookies()
-        self._session_token = None
         self._logged_in = False
 
     def _get_configuration(self, username: str) -> ChargePointGlobalConfiguration:
@@ -164,20 +163,36 @@ class ChargePoint:
         )
         return config
 
+    def refresh_session_token(self):
+        _LOGGER.debug("Requesting long lived token")
+        response = self._session.post(
+            f"{self._global_config.endpoints.webservices}mobileapi/v5", json={"user_id": self.user_id}
+        )
+
+        token = [cookie for cookie in response.cookies if cookie.name == 'coulomb_sess']
+        if (response.status_code != codes.ok) or not token:
+            _LOGGER.error(
+                "Failed to get long lived token! status_code=%s err=%s",
+                response.status_code,
+                response.text,
+            )
+            raise ChargePointCommunicationException(
+                response=response, message="Failed to retrieve long lived token."
+            )
+
+    def _get_session_token(self) -> str:
+        out =''
+        token = [cookie for cookie in self._session.cookies if cookie.name == 'coulomb_sess']
+
+        if token:
+            out = token[0].value
+
+        return out
+
     def _set_session_token(self, session_token: str):
-        try:
-            self._session.headers = {
-                "cp-session-type": "CP_SESSION_TOKEN",
-                "cp-session-token": session_token,
-                # Data:       |------------------Token Data------------------||---?---||-Reg-|
-                # Session ID: rAnDomBaSe64EnCodEdDaTaToKeNrAnDomBaSe64EnCodEdD#D???????#RNA-US
-                "cp-region": session_token.split("#R")[1],
-                "user-agent": "ChargePoint/236 (iPhone; iOS 15.3; Scale/3.00)",
-            }
-        except IndexError:
+        if len(session_token) != 32:
             raise ChargePointBaseException("Invalid session token format.")
 
-        self._session_token = session_token
         self._session.cookies.set("coulomb_sess", session_token)
 
     @_require_login

--- a/python_chargepoint/client.py
+++ b/python_chargepoint/client.py
@@ -2,6 +2,7 @@ from uuid import uuid4
 from typing import List, Optional
 from functools import wraps
 from time import sleep
+from importlib.metadata import version, PackageNotFoundError
 
 from requests import Session, codes, post
 
@@ -21,7 +22,14 @@ from .exceptions import (
 from .global_config import ChargePointGlobalConfiguration
 from .session import ChargingSession
 from .constants import _LOGGER, DISCOVERY_API
+from . import __name__ as MODULE_NAME
 
+try:
+    MODULE_VERSION = version(MODULE_NAME)
+except PackageNotFoundError:
+    MODULE_VERSION = "unknown"
+
+USER_AGENT = f"{MODULE_NAME}/{MODULE_VERSION}"
 
 def _require_login(func):
     @wraps(func)
@@ -48,10 +56,8 @@ class ChargePoint:
         username: str,
         password: str,
         session_token: str = "",
-        app_version: str = "5.97.0",
     ):
         self._session = Session()
-        self._app_version = app_version
         self._user_id = None
         self._logged_in = False
         self._session_token = None
@@ -99,7 +105,7 @@ class ChargePoint:
             f"{self._global_config.endpoints.accounts}v2/driver/profile/account/login"
         )
         headers = {
-            "User-Agent": f"com.coulomb.ChargePoint/{self._app_version} CFNetwork/1329 Darwin/21.3.0"
+            "User-Agent": USER_AGENT
         }
         request = {
             "username": username,

--- a/python_chargepoint/client.py
+++ b/python_chargepoint/client.py
@@ -23,16 +23,6 @@ from .session import ChargingSession
 from .constants import _LOGGER, DISCOVERY_API
 
 
-def _dict_for_query(device_data: dict) -> dict:
-    """
-    GET requests send device data as a nested object.
-    To avoid storing the device data block in two
-    formats, we are just going to compute the flat
-    dictionary.
-    """
-    return {f"deviceData[{key}]": value for key, value in device_data.items()}
-
-
 def _require_login(func):
     @wraps(func)
     def check_login(*args, **kwargs):
@@ -62,17 +52,6 @@ class ChargePoint:
     ):
         self._session = Session()
         self._app_version = app_version
-        self._device_data = {
-            "appId": "com.coulomb.ChargePoint",
-            "manufacturer": "Apple",
-            "model": "iPhone",
-            "notificationId": "",
-            "notificationIdType": "",
-            "type": "IOS",
-            "udid": str(uuid4()),
-            "version": app_version,
-        }
-        self._device_query_params = _dict_for_query(self._device_data)
         self._user_id = None
         self._logged_in = False
         self._session_token = None
@@ -105,9 +84,6 @@ class ChargePoint:
     def session_token(self) -> Optional[str]:
         return self._session_token
 
-    @property
-    def device_data(self) -> dict:
-        return self._device_data
 
     @property
     def global_config(self) -> ChargePointGlobalConfiguration:
@@ -126,7 +102,6 @@ class ChargePoint:
             "User-Agent": f"com.coulomb.ChargePoint/{self._app_version} CFNetwork/1329 Darwin/21.3.0"
         }
         request = {
-            "deviceData": self._device_data,
             "username": username,
             "password": password,
         }
@@ -153,7 +128,6 @@ class ChargePoint:
     def logout(self):
         response = self._session.post(
             f"{self._global_config.endpoints.accounts}v1/driver/profile/account/logout",
-            json={"deviceData": self._device_data},
         )
 
         if response.status_code != codes.ok:
@@ -168,7 +142,7 @@ class ChargePoint:
 
     def _get_configuration(self, username: str) -> ChargePointGlobalConfiguration:
         _LOGGER.debug("Discovering account region for username %s", username)
-        request = {"deviceData": self._device_data, "username": username}
+        request = {"username": username}
         response = self._session.post(DISCOVERY_API, json=request)
         if response.status_code != codes.ok:
             raise ChargePointCommunicationException(
@@ -205,7 +179,6 @@ class ChargePoint:
         _LOGGER.debug("Getting ChargePoint Account Details")
         response = self._session.get(
             f"{self._global_config.endpoints.accounts}v1/driver/profile/user",
-            params=self._device_query_params,
         )
 
         if response.status_code != codes.ok:
@@ -226,7 +199,6 @@ class ChargePoint:
         _LOGGER.debug("Listing vehicles")
         response = self._session.get(
             f"{self._global_config.endpoints.accounts}v1/driver/vehicle",
-            params=self._device_query_params,
         )
 
         if response.status_code != codes.ok:
@@ -334,7 +306,7 @@ class ChargePoint:
     @_require_login
     def get_user_charging_status(self) -> Optional[UserChargingStatus]:
         _LOGGER.debug("Checking account charging status")
-        request = {"deviceData": self._device_data, "user_status": {"mfhs": {}}}
+        request = {"user_status": {"mfhs": {}}}
         response = self._session.post(
             f"{self._global_config.endpoints.mapcache}v2", json=request
         )
@@ -364,7 +336,6 @@ class ChargePoint:
     ) -> None:
         _LOGGER.debug(f"Setting amperage limit for {charger_id} to {amperage_limit}")
         request = {
-            "deviceData": self._device_data,
             "chargeAmperageLimit": amperage_limit,
         }
         response = self._session.post(


### PR DESCRIPTION
This PR implements a log in and token provisioning flow which uses ChargePoint's primary SSO endpoint and avoids running afoul of Captcha issues on the previous login endpoint. 

Additional changes:

- Removed device_id from request bodies and references to the ChargePoint iOS app in headers. Replaced with a header that clearly identifies python-chargepoint and it's version as the user-agent. ChargePoint does not block requests based on this header and we should not be sending knowingly false information.
- Replaced the client _session_token attribute with a method that reads out the value of 'the coulomb_sess' cookie from the client session object directly (if it exists). The session object updates this cookie whenever a request response includes a SetCookie header containing it. 
- Added a refresh_session_token method to retrieve a new long lived 'coulomb_sess' token. The webservices mobileapi v5 sets a new 'coulomb_sess' cookie with 6 months validity with every successful call that includes a valid 'auth-session' or 'coulomb_sess' cookie AND the matching user ID in the json request.

closes #11 
closes #14 
closes #15